### PR TITLE
Abnormal memory increase in eval step

### DIFF
--- a/finetune/train.py
+++ b/finetune/train.py
@@ -199,9 +199,6 @@ def compute_metrics(eval_pred):
     valid_predictions = predictions[valid_mask]
     valid_labels = labels[valid_mask]
 
-    pred_prob = softmax(logits, axis=1)
-    pred_prob = pred_prob[:,[1]].flatten()
-
     return {
         "accuracy": sklearn.metrics.accuracy_score(valid_labels, valid_predictions),
         "f1": sklearn.metrics.f1_score(
@@ -215,12 +212,6 @@ def compute_metrics(eval_pred):
         ),
         "recall": sklearn.metrics.recall_score(
             valid_labels, valid_predictions, average="macro", zero_division=0
-        ),
-        "auPRCs": sklearn.metrics.average_precision_score(
-            y_true=valid_labels, y_score=pred_prob
-        ),
-        "auROC": sklearn.metrics.roc_auc_score(
-            y_true=valid_labels, y_score=pred_prob
         )
     }
 

--- a/finetune/train.py
+++ b/finetune/train.py
@@ -298,7 +298,8 @@ def train():
                                    compute_metrics=compute_metrics,
                                    train_dataset=train_dataset,
                                    eval_dataset=val_dataset,
-                                   data_collator=data_collator)
+                                   data_collator=data_collator,
+                                   preprocess_logits_for_metrics=preprocess_logits_for_metrics)
     trainer.train()
 
     if training_args.save_model:

--- a/finetune/train.py
+++ b/finetune/train.py
@@ -184,16 +184,24 @@ class DataCollatorForSupervisedDataset(object):
         )
 
 """
-Manually calculate the accuracy, f1, matthews_correlation, precision, recall with sklearn.
-"""
-def calculate_metric_with_sklearn(logits: np.ndarray, labels: np.ndarray):
+Compute metrics used for huggingface trainer.
+""" 
+def compute_metrics(eval_pred):
+    logits = eval_pred.predictions[0] # predictions[1] is label pass through preprocess_logits_for_metrics()
+    labels = eval_pred.label_ids
+
     if logits.ndim == 3:
         # Reshape logits to 2D if needed
         logits = logits.reshape(-1, logits.shape[-1])
+
     predictions = np.argmax(logits, axis=-1)
     valid_mask = labels != -100  # Exclude padding tokens (assuming -100 is the padding token ID)
     valid_predictions = predictions[valid_mask]
     valid_labels = labels[valid_mask]
+
+    pred_prob = softmax(logits, axis=1)
+    pred_prob = pred_prob[:,[1]].flatten()
+
     return {
         "accuracy": sklearn.metrics.accuracy_score(valid_labels, valid_predictions),
         "f1": sklearn.metrics.f1_score(
@@ -208,18 +216,27 @@ def calculate_metric_with_sklearn(logits: np.ndarray, labels: np.ndarray):
         "recall": sklearn.metrics.recall_score(
             valid_labels, valid_predictions, average="macro", zero_division=0
         ),
+        "auPRCs": sklearn.metrics.average_precision_score(
+            y_true=valid_labels, y_score=pred_prob
+        ),
+        "auROC": sklearn.metrics.roc_auc_score(
+            y_true=valid_labels, y_score=pred_prob
+        )
     }
 
-
 """
-Compute metrics used for huggingface trainer.
+Fix memory problem in eval_step when using compute_metrics
 """ 
-def compute_metrics(eval_pred):
-    logits, labels = eval_pred
-    if isinstance(logits, tuple):  # Unpack logits if it's a tuple
-        logits = logits[0]
-    return calculate_metric_with_sklearn(logits, labels)
+def preprocess_logits_for_metrics(logits, labels):
+    """
+    Original Trainer may have a memory leak. 
+    This is a workaround to avoid storing too many tensors that are not needed.
+    """
+    # logits = (model output logits, dnabert output)
+    # model output logits : (bs, 2) 
+    # dnabert output : (bs, 452, 768)
 
+    return logits[0], labels
 
 
 def train():


### PR DESCRIPTION
This problem is caused by using the trainer provided by the transformers package. The memory usage will increase abnormally during the eval step when using customized `compute_metrics()`, but there is no problem during training. 

I finetune my data set. The size of my evaluation set was about 27k. There was insufficient memory at the beginning. I used the `eval_accumulation_steps ` parameter to put the evaluation part on the CPU. and it work, but  in the end the RAM usage was It reaches 140 GB, and it takes a long time.

my related settings:
-  model_max_length=500 
-  per_device_eval_batch_size=16

 refer to [this article](https://discuss.huggingface.co/t/cuda-out-of-memory-when-using-trainer-with-compute-metrics/2941/11), I fixed this issue with  add `preprocess_logits_for_metrics()`  under the trainer.

In our code, we need to exclude dnabert last layer output in `preprocess_logits_for_metrics()`  before the trainer passes the output to `compute_metrics()` (it will be passed out together with the output classification logits by default) to avoid taking up too much memory.