### PR TITLE
Added package versions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-einops
+einops==0.6.1
 transformers==4.29.2
-peft
-omegaconf
-torch
-evaluate
-accelerate
+peft==0.3.0
+omegaconf==2.3.0
+torch==1.13.1
+evaluate==0.4.0
+accelerate==0.20.3
+scikit-learn==1.2.2


### PR DESCRIPTION
After meeting several compatibility issues while setting up the virtual environment for running the model, I retrieved the specific versions of packages and added to requirements.txt. Now inference and finetuning work without any problem. However, I was not able to install a compatible version of Triton.