### PR TITLE
Add Continuous Integration script to reproduce error `assert q.is_cuda and k.is_cuda and v.is_cuda`

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,0 +1,24 @@
+# Checks if the build works, 
+# by installing the requirements
+# and then running the example code
+
+name: Check build
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  check_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: install required packages
+        run: python3 -m pip install -r requirements.txt
+
+      - name: run example code shown in README
+        run: python3 .github/workflows/example_huggingface_v4_28.py

--- a/.github/workflows/example_huggingface_newer_than_v4_28.py
+++ b/.github/workflows/example_huggingface_newer_than_v4_28.py
@@ -1,0 +1,16 @@
+from transformers.models.bert.configuration_bert import BertConfig
+
+config = BertConfig.from_pretrained("zhihan1996/DNABERT-2-117M")
+model = AutoModel.from_pretrained("zhihan1996/DNABERT-2-117M", trust_remote_code=True, config=config)
+
+dna = "ACGTAGCATCGGATCTATCTATCGACACTTGGTTATCGATCTACGAGCATCTCGTTAGC"
+inputs = tokenizer(dna, return_tensors = 'pt')["input_ids"]
+hidden_states = model(inputs)[0] # [1, sequence_length, 768]
+
+# embedding with mean pooling
+embedding_mean = torch.mean(hidden_states[0], dim=0)
+print(embedding_mean.shape) # expect to be 768
+
+# embedding with max pooling
+embedding_max = torch.max(hidden_states[0], dim=0)[0]
+print(embedding_max.shape) # expect to be 768

--- a/.github/workflows/example_huggingface_v4_28.py
+++ b/.github/workflows/example_huggingface_v4_28.py
@@ -1,0 +1,17 @@
+import torch
+from transformers import AutoTokenizer, AutoModel
+
+tokenizer = AutoTokenizer.from_pretrained("zhihan1996/DNABERT-2-117M", trust_remote_code=True)
+model = AutoModel.from_pretrained("zhihan1996/DNABERT-2-117M", trust_remote_code=True)
+
+dna = "ACGTAGCATCGGATCTATCTATCGACACTTGGTTATCGATCTACGAGCATCTCGTTAGC"
+inputs = tokenizer(dna, return_tensors = 'pt')["input_ids"]
+hidden_states = model(inputs)[0] # [1, sequence_length, 768]
+
+# embedding with mean pooling
+embedding_mean = torch.mean(hidden_states[0], dim=0)
+print(embedding_mean.shape) # expect to be 768
+
+# embedding with max pooling
+embedding_max = torch.max(hidden_states[0], dim=0)[0]
+print(embedding_max.shape) # expect to be 768


### PR DESCRIPTION
Dear DNABERT 2 maintainer,

With this Pull Request I'd like to prove that the documentation is incomplete, by reproducing the error

```
assert q.is_cuda and k.is_cuda and v.is_cuda
```

This error is reported too in #11, #20, #34, #96 and #112.

I made the error reproducible with the script in `.github/workflow/check_build.yaml`, where I copy-paste the install process only. I simply followed the install procedure in the README, using the recommended Python 3.8, yet without the conda setup:

```text
- uses: actions/setup-python@v2
  with:
    python-version: 3.8

- name: install required packages
  run: python3 -m pip install -r requirements.txt

- name: run example code shown in README
  run: python3 .github/workflows/example_huggingface_v4_28.py
```

The script it runs is copied from the README too:

```python
import torch
from transformers import AutoTokenizer, AutoModel

tokenizer = AutoTokenizer.from_pretrained("zhihan1996/DNABERT-2-117M", trust_remote_code=True)
model = AutoModel.from_pretrained("zhihan1996/DNABERT-2-117M", trust_remote_code=True)

dna = "ACGTAGCATCGGATCTATCTATCGACACTTGGTTATCGATCTACGAGCATCTCGTTAGC"
inputs = tokenizer(dna, return_tensors = 'pt')["input_ids"]
hidden_states = model(inputs)[0] # [1, sequence_length, 768]

# embedding with mean pooling
embedding_mean = torch.mean(hidden_states[0], dim=0)
print(embedding_mean.shape) # expect to be 768

# embedding with max pooling
embedding_max = torch.max(hidden_states[0], dim=0)[0]
print(embedding_max.shape) # expect to be 768
```

The error log is shown in the next message below.

I think that a user should be able to install a Python module and run example code with success by reading the documentation, hence I think the documentation is incomplete or the error message given is not helpful enough (#112). 

I hope you appreciate the effort I put in to make DNABERT 2 even better for everyone. Maybe using CI scripts is new to you, I'd be happy to discuss their pros and cons and I'd be happy to maintain such scripts for my users :-)

Cheers, Richel Bilderbeek